### PR TITLE
Fix missing backend endpoint for Lab10

### DIFF
--- a/WebDev_lab10/backend_rooms.php
+++ b/WebDev_lab10/backend_rooms.php
@@ -1,0 +1,14 @@
+<?php
+// backend_rooms.php - returns room data as JSON
+header('Content-Type: application/json');
+require_once '_db.php';
+
+try {
+    $stmt = $db->prepare("SELECT * FROM rooms ORDER BY name");
+    $stmt->execute();
+    $rooms = $stmt->fetchAll(PDO::FETCH_ASSOC);
+    echo json_encode($rooms);
+} catch (Exception $e) {
+    http_response_code(500);
+    echo json_encode(['error' => $e->getMessage()]);
+}


### PR DESCRIPTION
## Summary
- add `backend_rooms.php` to provide room data via AJAX

## Testing
- `node -v`


------
https://chatgpt.com/codex/tasks/task_e_6858044ea2b883329ecfd0724a39c772